### PR TITLE
Dockerize app

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.cache
+*.md
+node_modules
+Dockerfile
+docs
+certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu
+
+WORKDIR /app
+
+COPY . .
+
+RUN apt update \
+&& apt install wget unzip -y \
+&& setup/pre.sh \
+&& setup/ubuntu.sh \
+&& setup/post.sh
+
+RUN mkdir -p certificates/intermediaries \
+&& mkdir -p certificates/results
+
+ENTRYPOINT ["node", "./index.js"]

--- a/setup/ubuntu.sh
+++ b/setup/ubuntu.sh
@@ -21,6 +21,11 @@ apt -y install wget curl unzip nodejs npm nano
 # https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
 apt -y install gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils libatk-bridge2.0-0
 
+# GET YARN(https://yarnpkg.com/lang/en/docs/install/#debian-stable)
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+apt -y update && apt -y install yarn
+
 # GET CHROME (https://gist.github.com/ziadoz/3e8ab7e944d02fe872c3454d17af31a5)
 
 curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add


### PR DESCRIPTION
This PR adds a Dockerfile and relavent changes for Dockerizing the app. I tried not to change the exsisiting scripts to my best.

**How to build the Docker image**

```
docker build -t google/certificate-master .
```

**How to use the Docker image**

```
docker run \
-v $PWD/certificates:/app/certificates \
-v $PWD/docs:/app/docs \
google/certificate-master --csv_file docs/example.csv --no-upload
```